### PR TITLE
Bug with memberUid attribute population

### DIFF
--- a/gosyncmodules/InitialPopulateToLdap.go
+++ b/gosyncmodules/InitialPopulateToLdap.go
@@ -41,10 +41,11 @@ func InitialPopulateToLdap(ADElements *[]LDAPElement, connectLDAP *ldap.Conn,
 					}
 				}
 				mappingvalue, ok := mapping[key]
+				//uid := maps["uid"]
 				if ok == true {
 					if mappingvalue == "memberUid"{
 						//members := memberTomemberUid(&value)
-						Add.Attribute(mappingvalue, memberTomemberUid(&value))
+						Add.Attribute(mappingvalue, memberTomemberUid(&value, ADElements))
 						continue
 					}
 					Add.Attribute(mappingvalue, value.([]string))

--- a/gosyncmodules/memberToMemberUID.go
+++ b/gosyncmodules/memberToMemberUID.go
@@ -2,11 +2,11 @@ package gosyncmodules
 
 import (
 	"strings"
-	"regexp"
-//	"fmt"
+	"reflect"
 )
 
-func memberTomemberUid(member *interface{})  []string{
+/*
+func memberTomemberUid(member *interface{}, uid *keyvalue)  []string{
 	Info.Println("Found member attribute ", *member, "converting it to memberUid")
 	matchCN := regexp.MustCompile("CN=")
 	memberlist := make([]string, 0)
@@ -19,4 +19,41 @@ func memberTomemberUid(member *interface{})  []string{
 	//fmt.Println(memberlist, "\n\n\n\n")
 	return memberlist
 
+}
+*/
+
+// memberTomemberUid function will populate memberUid attribute with the corresponding uid field
+// from the entire ldap request slice. Parameters are the member attribute slice which is of
+// type interface{}
+func memberTomemberUid(member *interface{}, fullmap *[]LDAPElement)  []string{
+	uids := make([]string, 0)
+	for _, members := range (*member).([]string) {
+		uid := checkMemberUIDInLDAPElements(members, fullmap)
+		if uid != nil {
+			uids = append(uids, *uid)
+		}
+
+	}
+	Info.Println("retrieved members as ", uids)
+	return uids
+
+}
+
+//
+func checkMemberUIDInLDAPElements(members string, fullmap *[]LDAPElement) *string{
+	for _, i := range *fullmap {
+		if reflect.DeepEqual(i.DN, members){
+			for _, maps := range i.attributes{
+				for k, v := range maps {
+					if k == "uid" {
+						uid := strings.Join(v.([]string), "")
+						return &uid
+					}
+
+				}
+			}
+		}
+	}
+	//fmt.Println(uids)
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os/user"
 	"fmt"
 	"os"
-//	"gosyncmodules"
-	"github.com/nohupped/ADtoLDAP/gosyncmodules"
+	"ADtoLDAP/gosyncmodules"
+//	"github.com/nohupped/ADtoLDAP/gosyncmodules"
 	"reflect"
 //	"os/signal"
 	"github.com/nohupped/ldap" //using a forked version that includes custom methods to retrieve and edit *AddRequest struct.
@@ -203,20 +203,20 @@ func main() {
 			for ; ; {
 				select {
 				case Add := <- AddChan:
-					for _, v := range Add {
-					//	gosyncmodules.Info.Println(k, ":", v)
+					for k, v := range Add {
+						gosyncmodules.Info.Println(k, ":", v)
 						err := LDAPConnection.Add(v)
 						if err != nil {
-							//gosyncmodules.Error.Println(err)
+							gosyncmodules.Error.Println(err)
 						}
 					}
 				case Del := <- DelChan:
-					for _, v := range Del  {
-					//	gosyncmodules.Info.Println(k, ":", v)
+					for k, v := range Del  {
+						gosyncmodules.Info.Println(k, ":", v)
 						delete := ldap.NewDelRequest(v.DN, []ldap.Control{})
 						err := LDAPConnection.Del(delete)
 						if err != nil {
-							//gosyncmodules.Error.Println(err)
+							gosyncmodules.Error.Println(err)
 						}
 					}
 				case shutdownAdd := <- shutdownAddChan:


### PR DESCRIPTION
 The memberUid attribute of a group is populated with the "CN" attribute of a user, which could possibly put invalid users. Changing it to use "uid" attribute
