### PR TITLE
custom logfile path and fileperm checks

### DIFF
--- a/gosyncmodules/logger.go
+++ b/gosyncmodules/logger.go
@@ -51,7 +51,7 @@ func logInit(traceHandle io.Writer, infoHandle io.Writer, warningHandle io.Write
 }
 
 func StartLog(logfile string, user *user.User, TAG ...string) *os.File{
-	file, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(logfile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		fmt.Println("Cannot open logfile")
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -32,17 +32,19 @@ import (
 func main() {
 
 	// Initialize logger
-	logfileMain := "/var/log/ldapsync.log"
-	username, err := user.Current()
-	gosyncmodules.CheckForError(err)
-	loggerMain := gosyncmodules.StartLog(logfileMain, username)
-	defer loggerMain.Close()
+
 
 	// Flags
 	checkSafety := flag.Bool("safe", true, "Set it to false to skip config file securitycheck")
 	syncrun := flag.String("sync", "daemon", "Set it to \"once\" for a single run, and \"daemon\" to run it continuously")
 	configFile := flag.String("configfile", "/etc/ldapsync.ini", "Path to the config file")
+	logfile := flag.String("logfile", "/var/log/ldapsync.log", "Path to log file. Defaults to /var/log/ldapsync.log")
 	flag.Parse()
+
+	username, err := user.Current()
+	gosyncmodules.CheckForError(err)
+	loggerMain := gosyncmodules.StartLog(*logfile, username)
+	defer loggerMain.Close()
 
 
 	gosyncmodules.Info.Println("safe option set to", *checkSafety)


### PR DESCRIPTION
- uses flag to accept custom log file path, which if not provided, takes default path as "/var/log/ldapsync.log". The file will be created with 0600 permission if it doesn't exist.
- Config file check will verify if the file is owned by the current user, and is group/world readable. If it is not owned by current user: current group and not have 600 permission, the program doesnt proceed. This can be over-ridden with `--safe=false`.

Fixes #5 
Fixes #3 
Fixes #4 