### PR TITLE
custom logfile path and fileperm checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ldapadd -Q -Y EXTERNAL -H ldapi:/// -f 2refint.ldif
 
 ##### The permission of /etc/ldapsync.ini
 
-The program checks if the file permissions for /etc/ldapsync.ini are too broad. If it is not 600, the program will report that, and will not start. This is checked to prevent a non-privileged read of the username and password used to bind to both the servers, which are stored in this configuration file. This can be over-ridden by running the program with the flag `--safe=false`.
+The program checks if the file permissions for /etc/ldapsync.ini are too broad. If it is not 600, the program will report that, and will not start. This can be over-ridden by running the program with the flag `--safe=false`.
 
 ##### 
 /etc/ldapsync.ini file for syncing from Active directory to an openldap server:


### PR DESCRIPTION
- uses flag to accept custom log file path, which if not provided, takes default path as "/var/log/ldapsync.log". The file will be created with 0600 permission if it doesn't exist.
- Config file check will verify if the file is owned by the current user, and is group/world readable. If it is not owned by current user: current group and not have 600 permission, the program doesnt proceed. This can be over-ridden with `--safe=false`.