### PR TITLE
Remove CGO from file permission checking

### DIFF
--- a/gosyncmodules/CheckPerm.go
+++ b/gosyncmodules/CheckPerm.go
@@ -5,51 +5,56 @@ import (
 	"os"
 	"os/user"
 	"strconv"
-	"unsafe"
+	"syscall"
 )
 
-//#include <sys/stat.h>
-//#include <stdlib.h>
-import "C"
+// Constants S_IRGRP, S_IWGRP, S_IXGRP, S_IROTH, S_IWOTH and S_IXOTH values are taken straight from /stat.h.
+// Ref: https://github.com/torvalds/linux/blob/master/include/uapi/linux/stat.h
+const (
+	IRGRP = 0000040
+	IWGRP = 0000020
+	IXGRP = 0000010
+	IROTH = 0000004
+	IWOTH = 0000002
+	IXOTH = 0000001
+)
 
+// CheckPerm checks permission of the passed filename(string) and panics if group or others have > read permissions.
 func CheckPerm(filename string) {
-	current_uid := os.Getuid()
-	current_gid := os.Getgid()
-	username, err := user.LookupId(strconv.Itoa(current_uid))
-	var current_username string
-	var current_groupname string
+	currentUID := os.Getuid()
+	currentGID := os.Getgid()
+	username, err := user.LookupId(strconv.Itoa(currentUID))
+	var currentUserName string
+	var currentGroupName string
 	if err != nil {
-		current_username = "<Couldn't lookup username>"
+		currentUserName = "<Couldn't lookup username>"
 	}
-	groupname, err := user.LookupGroupId(strconv.Itoa(current_gid))
+	groupname, err := user.LookupGroupId(strconv.Itoa(currentGID))
 	if err != nil {
-		current_groupname = "<Couldn't lookup groupname>"
+		currentGroupName = "<Couldn't lookup groupname>"
 
 	}
-	current_username = username.Username
-	current_groupname = groupname.Name
+	currentUserName = username.Username
+	currentGroupName = groupname.Name
 
-	logger.Infoln("using cgo to perform security check on ", filename)
-	statstruct := C.stat //stat struct from C
-	logger.Infoln("Initiated stat struct")
-	path := C.CString(filename)
-	logger.Infoln("Converted native string to C.CString")
-	st := *(*C.struct_stat)(unsafe.Pointer(statstruct)) //Casting unsafe pointer to C.struct_stat
-	logger.Infoln("Casting unsafe.Pointer(stat) to *(*C.struct_stat)")
-	defer C.free(unsafe.Pointer(path)) //free the C.CString that is created in heap.
-	C.stat(path, &st)
-	uid := st.st_uid
-	gid := st.st_gid
-	if int(uid) != current_uid || int(gid) != current_gid {
-		fmt.Printf("%s not owned by uid=%d(%s) or gid=%d(%s). Do chown %d:%d %s\n", filename, current_uid, current_username, current_gid, current_groupname, current_uid, current_gid, filename)
-		logger.Infof("%s not owned by uid=%d(%s) or gid=%d(%s). Do chown %d:%d %s\n", filename, current_uid, current_username, current_gid, current_groupname, current_uid, current_gid, filename)
+	fileStat, err := os.Stat(filename)
+	if err != nil {
+		panic(err)
+	}
+	filestatSys := fileStat.Sys().(*syscall.Stat_t)
+	uid := filestatSys.Uid
+	gid := filestatSys.Gid
+	if int(uid) != currentUID || int(gid) != currentGID {
+		fmt.Printf("%s not owned by uid=%d(%s) or gid=%d(%s). Do chown %d:%d %s\n", filename, currentUID, currentUserName, currentGID, currentGroupName, currentUID, currentGID, filename)
+		logger.Errorf("%s not owned by uid=%d(%s) or gid=%d(%s). Do chown %d:%d %s\n", filename, currentUID, currentUserName, currentGID, currentGroupName, currentUID, currentGID, filename)
 		os.Exit(1)
 	}
-	if st.st_mode&C.S_IRGRP > 0 || st.st_mode&C.S_IWGRP > 0 || st.st_mode&C.S_IXGRP > 0 ||
-		st.st_mode&C.S_IROTH > 0 || st.st_mode&C.S_IWOTH > 0 || st.st_mode&C.S_IXOTH > 0 {
+	if filestatSys.Mode&IRGRP > 0 || filestatSys.Mode&IWGRP > 0 || filestatSys.Mode&IXGRP > 0 ||
+	   filestatSys.Mode&IROTH > 0 || filestatSys.Mode&IWOTH > 0 || filestatSys.Mode&IXOTH > 0 {
 		fmt.Println(filename, "file permission too broad, make it non-readable to groups and others.")
-		logger.Infoln(filename, "file permission too broad, make it non-readable to groups and others.")
+		logger.Errorln(filename, "file permission too broad, make it non-readable to groups and others.")
 		os.Exit(1)
 	}
 	logger.Infoln("File permission looks secure")
 }
+


### PR DESCRIPTION
- got rid of cgo and use `os.Stat()`


Fixes #15 