### PR TITLE
fix module path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ADtoLDAP
+module github.com/nohupped/ADtoLDAP
 
 go 1.13
 
@@ -8,6 +8,5 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ini.v1 v1.55.0
-	github.com/nohupped/ADtoLDAP v0.0.0-20200426131947-c166814580d5
 	gopkg.in/ldap.v2 v2.5.1
 )


### PR DESCRIPTION
Change module path to  `module github.com/nohupped/ADtoLDAP`

Fixes #22 